### PR TITLE
feat(seo): add sitemap generator

### DIFF
--- a/scribbleseekerr_frontend/next-sitemap.config.js
+++ b/scribbleseekerr_frontend/next-sitemap.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+    siteUrl: 'https://scribbleseekerr.vercel.app/',
+    generateRobotsTxt: true,
+  }

--- a/scribbleseekerr_frontend/package-lock.json
+++ b/scribbleseekerr_frontend/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-config-next": "13.4.7",
         "jest-fetch-mock": "^3.0.3",
         "next": "13.4.7",
+        "next-sitemap": "^4.2.2",
         "postcss": "8.4.23",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -671,6 +672,11 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ=="
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.11.0",
@@ -6537,6 +6543,32 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-sitemap": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.2.tgz",
+      "integrity": "sha512-cz5PyFibUNSJSXOY5mllq5TW0OH6SGG+8GJ9fR9pl1Thu4rvkDye+0N0790h+9kQihDStuVw2xfwC3qihDkflA==",
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.43",
+        "@next/env": "^13.4.3",
+        "fast-glob": "^3.2.12",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "next": "*"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/scribbleseekerr_frontend/package.json
+++ b/scribbleseekerr_frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --watch"
+    "test": "jest --watch",
+    "postbuild": "next-sitemap"
   },
   "dependencies": {
     "@lottiefiles/react-lottie-player": "^3.5.3",
@@ -21,6 +22,7 @@
     "eslint-config-next": "13.4.7",
     "jest-fetch-mock": "^3.0.3",
     "next": "13.4.7",
+    "next-sitemap": "^4.2.2",
     "postcss": "8.4.23",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/scribbleseekerr_frontend/public/robots.txt
+++ b/scribbleseekerr_frontend/public/robots.txt
@@ -1,0 +1,9 @@
+# *
+User-agent: *
+Allow: /
+
+# Host
+Host: https://scribbleseekerr.vercel.app/
+
+# Sitemaps
+Sitemap: https://scribbleseekerr.vercel.app/sitemap.xml

--- a/scribbleseekerr_frontend/public/sitemap-0.xml
+++ b/scribbleseekerr_frontend/public/sitemap-0.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://scribbleseekerr.vercel.app/create-post</loc><lastmod>2023-08-21T15:04:04.093Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scribbleseekerr.vercel.app/login</loc><lastmod>2023-08-21T15:04:04.093Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scribbleseekerr.vercel.app/user/edit</loc><lastmod>2023-08-21T15:04:04.093Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scribbleseekerr.vercel.app/guidelines</loc><lastmod>2023-08-21T15:04:04.093Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scribbleseekerr.vercel.app</loc><lastmod>2023-08-21T15:04:04.093Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scribbleseekerr.vercel.app/texts</loc><lastmod>2023-08-21T15:04:04.093Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scribbleseekerr.vercel.app/register</loc><lastmod>2023-08-21T15:04:04.093Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scribbleseekerr.vercel.app/user</loc><lastmod>2023-08-21T15:04:04.093Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+</urlset>

--- a/scribbleseekerr_frontend/public/sitemap.xml
+++ b/scribbleseekerr_frontend/public/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://scribbleseekerr.vercel.app/sitemap-0.xml</loc></sitemap>
+</sitemapindex>


### PR DESCRIPTION
For better SEO this automatically generates a robots.txt and a sitemap. The postbuild script automatically runs after the initial npm run build. This sitemap can also be submitted to the Google search console.